### PR TITLE
Fix orders pricing

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,6 +1,6 @@
 class OrdersController < ApplicationController
 	before_action :require_user
-	# before_action :find_order, only: [:cancel, :pay, :complete]
+	# before_save 
 
 	def index
 	end
@@ -18,6 +18,8 @@ class OrdersController < ApplicationController
 		order = Order.new(user_id: current_user.id)
 		order.add_items(@cart)
 		if order.save
+			order.add_unit_price_to_join(@cart)
+			# binding.pry
 			session[:cart].clear
 			flash[:success] = "Order was successfully placed"
 			redirect_to orders_path

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -11,4 +11,5 @@ class Item < ApplicationRecord
   def formatted_price
     sprintf('%.2f', price)
   end
+
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -7,7 +7,11 @@ class Order < ApplicationRecord
   enum status: %w(ordered paid cancelled completed)
 
   def total_order_price
-  	sanitize_price(items.sum(:price))
+  	sanitize_price(orders_items.sum(:unit_price))
+  end
+
+  def item_price(item)
+    sanitize_price(orders_items.find_by(order_id: self.id, item_id: item.id).unit_price)
   end
 
   def item_quantity(item)
@@ -17,7 +21,7 @@ class Order < ApplicationRecord
 
   def item_subtotal(item)
   	id = item.id
-  	sanitize_price(items.where(id: id).sum(:price))
+  	sanitize_price(orders_items.where(id: id).sum(:unit_price))
   end
 
   def sanitize_price(price)
@@ -28,6 +32,13 @@ class Order < ApplicationRecord
     cart.contents.each do |item_id, quantity|
       item = Item.find(item_id)
       quantity.to_i.times {items << item}
+    end
+  end
+
+  def add_unit_price_to_join(cart)
+    cart.contents.each do |item_id, quantity|
+      item = Item.find(item_id)
+      orders_items.where(item_id: item_id).update(unit_price: item.price)
     end
   end
 

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -21,7 +21,7 @@ class Order < ApplicationRecord
 
   def item_subtotal(item)
   	id = item.id
-  	sanitize_price(orders_items.where(id: id).sum(:unit_price))
+  	sanitize_price(orders_items.where(item_id: id).sum(:unit_price))
   end
 
   def sanitize_price(price)

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -10,7 +10,7 @@
 	<li>
 		Title: <%= link_to item.title, item_path(item) %>
 		Quantity: <%= @order.item_quantity(item) %>
-		Price: $<%= item.formatted_price %> Each
+		Price: $<%= @order.item_price(item) %> Each
 		Subtotal: $<%= @order.item_subtotal(item) %>
 	</li>
 	<% end %>

--- a/db/migrate/20170918232959_add_unit_price_to_orders_items.rb
+++ b/db/migrate/20170918232959_add_unit_price_to_orders_items.rb
@@ -1,0 +1,5 @@
+class AddUnitPriceToOrdersItems < ActiveRecord::Migration[5.1]
+  def change
+    add_column :orders_items, :unit_price, :float
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170916192502) do
+ActiveRecord::Schema.define(version: 20170918232959) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -46,6 +46,7 @@ ActiveRecord::Schema.define(version: 20170916192502) do
     t.bigint "order_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.float "unit_price"
     t.index ["item_id"], name: "index_orders_items_on_item_id"
     t.index ["order_id"], name: "index_orders_items_on_order_id"
   end

--- a/spec/factories/orders_items.rb
+++ b/spec/factories/orders_items.rb
@@ -2,5 +2,6 @@ FactoryGirl.define do
   factory :orders_item do
     item nil
     order nil
+    unit_price nil
   end
 end

--- a/spec/features/admin/admin_can_see_individual_order_spec.rb
+++ b/spec/features/admin/admin_can_see_individual_order_spec.rb
@@ -22,6 +22,10 @@ describe "Admin can view individual order" do
 			  item3 = order1.items.create(title: "Cool Item3", description: "Descrip3",
 			  													 price: 35.99, image: "http://lorempixel.com/400/200",
 			  													 category: category)
+			  
+			  OrdersItem.where(item_id: item1.id).update(unit_price: 35.0)
+			  OrdersItem.where(item_id: item2.id).update(unit_price: 35.50)
+			  OrdersItem.where(item_id: item3.id).update(unit_price: 35.99)
 
 	      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
 

--- a/spec/features/admin/admin_can_see_individual_order_spec.rb
+++ b/spec/features/admin/admin_can_see_individual_order_spec.rb
@@ -22,7 +22,7 @@ describe "Admin can view individual order" do
 			  item3 = order1.items.create(title: "Cool Item3", description: "Descrip3",
 			  													 price: 35.99, image: "http://lorempixel.com/400/200",
 			  													 category: category)
-			  
+
 			  OrdersItem.where(item_id: item1.id).update(unit_price: 35.0)
 			  OrdersItem.where(item_id: item2.id).update(unit_price: 35.50)
 			  OrdersItem.where(item_id: item3.id).update(unit_price: 35.99)

--- a/spec/features/admin/admin_changing_item_price_does_not_change_old_orders_spec.rb
+++ b/spec/features/admin/admin_changing_item_price_does_not_change_old_orders_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+describe "Admin changing price does not change order price info" do
+  context "user submits order and order has various price data" do
+    context "admin updates price of items used in order" do
+      scenario "order price info does not change to reflect new price" do
+        category = create(:category)
+        item1, item2, item3 = create_list(:item, 3, category: category, price: 10.0)
+        user = create(:user)
+
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+        visit items_path
+
+	      within ".index_item_#{item1.id}" do
+	        click_on "Add to Cart"
+	      end
+
+	      within ".index_item_#{item2.id}" do
+	      	click_on "Add to Cart"
+	      end
+
+	      within ".index_item_#{item2.id}" do
+	      	click_on "Add to Cart"
+	      end
+
+	      visit cart_path
+
+	      click_on "Checkout"
+
+	      click_on "View Order"
+
+	      expect(page).to have_content("Price: $10.00 Each")
+	      expect(page).to have_content("Subtotal: $10.00")
+	      expect(page).to have_content("Total Price: $30.00")
+
+        item1.update(price: 1000.0)
+
+        visit orders_path
+
+        click_on "View Order"
+
+	      expect(page).to have_content("Price: $10.00 Each")
+	      expect(page).to have_content("Subtotal: $10.00")
+	      expect(page).to have_content("Total Price: $30.00")
+      end
+    end
+  end
+end

--- a/spec/features/user/user_can_view_single_past_order_spec.rb
+++ b/spec/features/user/user_can_view_single_past_order_spec.rb
@@ -18,6 +18,10 @@ describe "User can see individual past order" do
 		  item3 = order.items.create(title: "Cool Item3", description: "Descrip3",
 		  													 price: 35.99, image: "http://lorempixel.com/400/200",
 		  													 category: category)
+
+	  	OrdersItem.where(item_id: item1.id).update(unit_price: 35.0)
+		  OrdersItem.where(item_id: item2.id).update(unit_price: 35.50)
+		  OrdersItem.where(item_id: item3.id).update(unit_price: 35.99)
 		  
 		  allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
 

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -43,6 +43,10 @@ RSpec.describe Order, type: :model do
                                    price: 35.99, image: "h`ttp://lorempixel.com/400/200",
                                    category: category)
 
+        OrdersItem.where(item_id: item_1.id).update(unit_price: 35.0)
+        OrdersItem.where(item_id: item2.id).update(unit_price: 35.50)
+        OrdersItem.where(item_id: item3.id).update(unit_price: 35.99)
+
         expect(order.total_order_price).to eq('106.49')
       end
 
@@ -79,9 +83,15 @@ RSpec.describe Order, type: :model do
         item3 = order.items.create(title: "Cool Item3", description: "Descrip3",
                                    price: 35.99, image: "h`ttp://lorempixel.com/400/200",
                                    category: category)
+
+
         4.times do
           order.items << item_1
         end
+
+        OrdersItem.where(item_id: item_1.id).update(unit_price: 35.0)
+        OrdersItem.where(item_id: item2.id).update(unit_price: 35.50)
+        OrdersItem.where(item_id: item3.id).update(unit_price: 35.99)
 
         expect(order.item_subtotal(item_1)).to eq('175.00')
       end


### PR DESCRIPTION
Related Issue: #122 

Summary: Fixed bug where updated item price updated all orders that included that item. Fixed all corresponding tests by essentially banging my head into the screen with increasing ferocity. 

Author(s): amhursh
